### PR TITLE
Correct delimiter character used in control_info.txt for sv-merge

### DIFF
--- a/genomon_pipeline_cloud/script/sv-merge.sh
+++ b/genomon_pipeline_cloud/script/sv-merge.sh
@@ -9,7 +9,7 @@ for i in `seq 1 $MAX_COUNT`; do
     TMP_INPUT_DIR=$(eval echo \$INPUT_DIR_${i})
     TMP_SAMPLE=$(eval echo \$SAMPLE_${i})
     if [ "$TMP_INPUT_DIR" != "" ]; then
-        echo "${TMP_SAMPLE}\t${TMP_INPUT_DIR}/${TMP_SAMPLE}" >> ${OUTPUT_DIR}/${PANEL_NAME}.control_info.txt
+        echo -e "${TMP_SAMPLE}\t${TMP_INPUT_DIR}/${TMP_SAMPLE}" >> ${OUTPUT_DIR}/${PANEL_NAME}.control_info.txt
     fi
 done
 


### PR DESCRIPTION
I'm not sure to which repo I should file this PR, but I'm posting it here just to showcase an issue and its cause I figured out.

When I tried to carry out a DNA pipeline execution with a control panel specified, I ran into an error like the following and the execution stopped along the way:

```
Traceback (most recent call last):
File "/usr/local/bin/GenomonSV", line 11, in <module>
sys.exit(main())
File "/usr/local/lib/python2.7/dist-packages/genomon_sv/__init__.py", line 9, in main
args.func(args)
File "/usr/local/lib/python2.7/dist-packages/genomon_sv/run.py", line 241, in genomonSV_merge
label, output_prefix = line.rstrip('\n').split('\t')
ValueError: need more than 1 value to unpack 
```

After some investigation, I figured out the cause of the error was that `sv-merge` failed to read its configuration file (`control_info.txt`) correctly because the delimiter character used in it was a literal `\t` (a backslash followed by letter T), not a raw tab character, by mistake.

To emit a raw tab character from bash's `echo` command, the option `-e` must be specified. This PR adds that option when generating the configuration file.